### PR TITLE
fix: remove extra unused arguments

### DIFF
--- a/Instal_prometeheus_setup_monitoring.sh
+++ b/Instal_prometeheus_setup_monitoring.sh
@@ -55,7 +55,7 @@ User=$USER
 TimeoutStartSec=0
 CPUWeight=95
 IOWeight=95
-ExecStart=prometheus --config.file=$HOME/prometheus/prometheus.yml --web.config.file=$HOME/prometheus/web.yml --storage.tsdb.path=$HOME/prometheus/data
+ExecStart=prometheus --config.file=$HOME/prometheus/prometheus.yml
 Restart=always
 RestartSec=2
 LimitNOFILE=800000


### PR DESCRIPTION
# Description
Remove extra unused arguments in prometheus service `ExecStart` in `Instal_prometeheus_setup_monitoring.sh`